### PR TITLE
強烈なViewのキャッシュ

### DIFF
--- a/src/core/Controller/Ctrl.php
+++ b/src/core/Controller/Ctrl.php
@@ -12,6 +12,7 @@ class Ctrl extends Core
 	private $_viewPath;
 	private $_viewFilePathName;
 	protected $_assign;
+	protected $viewStatic = false;
 
 	public function getUseView()
 	{
@@ -33,6 +34,31 @@ class Ctrl extends Core
 		$this->_assign[$name] = $data;
 	}
 
+	protected function viewJson($data = [])
+	{
+		if ($data) {
+			echo json_encode($data);
+		}
+		else
+		{
+			echo json_encode($this->_assig);
+		}
+		exit;
+	}
+
+	protected function isViewStatic()
+	{
+		try {
+			$view = new View($this->_assign);
+			$view->setPath($this->_viewFilePathName);
+			return $view->isStaticFileValid();
+		}
+		catch(Exception $e) {
+			throw $e;
+		}
+		return false;
+	}
+
 	protected function view($render = true)
 	{
 		try {
@@ -44,7 +70,14 @@ class Ctrl extends Core
 				}
 				$view = new View($this->_assign);
 				$view->setPath($this->_viewFilePathName);
-				$view->view();
+				if ($this->viewStatic)
+				{
+					$view->viewStatic();
+				}
+				else
+				{
+					$view->view();
+				}
 			}
 		}
 		catch(Exception $e) {

--- a/src/core/Trait/Cache.php
+++ b/src/core/Trait/Cache.php
@@ -98,6 +98,21 @@ trait Cache
 			throw $e;
 		}
 	}
+
+	public function deleteCacheFile($name)
+	{
+		try {
+			if (!$this->_cacheFilePathBase)
+			{
+				$this->getCacheDir();
+			}
+			$path = $this->_cacheFilePathBase.$name;
+			unlink($path);	
+		}
+		catch(Exception $e) {
+			throw $e;
+		}
+	}
 	
 	public function checkCacheValid($name, $time = 0)
 	{

--- a/src/core/View/View.php
+++ b/src/core/View/View.php
@@ -26,16 +26,15 @@ class View extends Core
 
 	public function view()
 	{
-		
 		$ftimeBase = filemtime($this->_path);
 		$baseDir = dirname(dirname(__DIR__)) . "/app/";
 		$cachePlusDir = str_replace($baseDir, "", $this->_path);
 		$baseFileName = basename($cachePlusDir);
 		$cachePlusDir = str_replace($baseFileName, "", $cachePlusDir);
 		$cacheFileName = str_replace(".tpl", ".dat", $baseFileName);
-		
-		$this->checkAndCreateCacheDirectory($cachePlusDir);
 
+		$this->checkAndCreateCacheDirectory($cachePlusDir);
+		
 		if ($this->checkCacheValid($cacheFileName))
 		{
 			$cacheTime = $this->getCacheFileTime($cacheFileName);
@@ -59,6 +58,76 @@ class View extends Core
 			}
 		}
 		require($this->getCacheFilePath($cacheFileName));
+	}
+
+	public function viewStatic()
+	{
+		ob_start();
+		$ftimeBase = filemtime($this->_path);
+		$baseDir = dirname(dirname(__DIR__)) . "/app/";
+		$cachePlusDir = str_replace($baseDir, "", $this->_path);
+		$baseFileName = basename($cachePlusDir);
+		$cachePlusDir = str_replace($baseFileName, "", $cachePlusDir);
+		$cacheTmpFileName = str_replace(".tpl", ".tmp.dat", $baseFileName);
+		$cacheFileName = str_replace(".tpl", ".static.dat", $baseFileName);
+		
+		$this->checkAndCreateCacheDirectory($cachePlusDir);
+		
+		if ($this->checkCacheValid($cacheFileName))
+		{
+			$cacheTime = $this->getCacheFileTime($cacheFileName);
+			if ($cacheTime < $ftimeBase)
+			{
+				$d = $this->compile();
+				$this->writeCacheFile($d, $cacheTmpFileName);
+				if ($this->_assign)
+				{
+					extract($this->_assign, EXTR_SKIP);
+				}
+				require($this->getCacheFilePath($cacheTmpFileName));
+				$staticData =ob_get_contents();
+				$this->writeCacheFile($staticData, $cacheFileName);
+				$this->deleteCacheFile($cacheTmpFileName);
+			}
+		}
+		else
+		{
+			$d = $this->compile();
+			$this->writeCacheFile($d, $cacheTmpFileName);
+			if ($this->_assign)
+			{
+				extract($this->_assign, EXTR_SKIP);
+			}
+			require($this->getCacheFilePath($cacheTmpFileName));
+			$staticData = ob_get_contents();
+			$this->writeCacheFile($staticData, $cacheFileName);
+			$this->deleteCacheFile($cacheTmpFileName);
+		}
+		ob_end_clean();
+		require($this->getCacheFilePath($cacheFileName));
+	}
+
+	public function isStaticFileValid()
+	{
+		$ftimeBase = filemtime($this->_path);
+		$baseDir = dirname(dirname(__DIR__)) . "/app/";
+		$cachePlusDir = str_replace($baseDir, "", $this->_path);
+		$baseFileName = basename($cachePlusDir);
+		$cachePlusDir = str_replace($baseFileName, "", $cachePlusDir);
+		$cacheFileName = str_replace(".tpl", ".static.dat", $baseFileName);
+		
+		$this->checkAndCreateCacheDirectory($cachePlusDir);
+		
+		if ($this->checkCacheValid($cacheFileName))
+		{
+			$cacheTime = $this->getCacheFileTime($cacheFileName);
+			if ($cacheTime > $ftimeBase)
+			{
+				return true;
+			}
+			
+		}
+		return false;
 	}
 
 	public function compile()


### PR DESCRIPTION
Ctrlのアクセス時呼び出しに
以下にすると強烈にキャッシュする
```php
public function Index()
{
	$this->viewStatic = true;
	if (!$this->isViewStatic())
	{
		//ここに最初に実行されてほしい処理とか割り当て処理
	}
	$this->view()
}
``` `
